### PR TITLE
Allow user to pass in install script source

### DIFF
--- a/.github/workflows/bats-install-tests.yml
+++ b/.github/workflows/bats-install-tests.yml
@@ -39,7 +39,7 @@ jobs:
           #   test_file: centos.bats
           # - os: amazonlinux:2023  
           #   test_file: centos.bats
-          - os: fedora:40
+          - os: fedora:42
             test_file: fedora.bats
 
     container:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Each test:
 - Verifies `puppet` binary in PATH
 - Checks `puppet version`
 
+### Running with your own domain and mirrored artifacts
+You can run this on your own servers with a few changes to the scripts.
+
+All the scripts have a BASE_URL variable that will need to point to your sources and artifacts.
+
+Example: `curl -fsSL https://raw.githubusercontent.com/logicminds/openvox-installer/refs/heads/main/install.sh | bash -s -- 8 openvox-agent https://raw.githubusercontent.com/logicminds/openvox-installer/refs/heads/main`
+
 
 ### Testing locally
 You can use the local script to run tests locally with docker

--- a/install-openvox-mac.sh
+++ b/install-openvox-mac.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-DMG_URL="https://downloads.voxpupuli.org/mac/openvox8/15/arm64/openvox-agent-8.13.0-1.osx15.dmg"
+# Please note that the DMG URL is hardcoded to the latest version of the OpenVox agent.
+# Openvox is new and packages for older OS versions do not exist yet.  This script
+# mainly works for ARM64 and macOS 15 as that is the only supported platform at the moment.
+
+OS_VERSION=$(sw_vers -productVersion | cut -d. -f1)
+AARCH=$(uname -m)
+AGENT_VERSION="${1:-8}"
+DMG_URL="https://downloads.voxpupuli.org/mac/openvox${AGENT_VERSION}/${OS_VERSION}/${AARCH}/openvox-agent-8.21.0-1.osx15.dmg"
 MOUNT_POINT="/Volumes/openvox-agent"
 TMP_DMG="/tmp/openvox-agent.dmg"
 BIN_DIR="/opt/puppetlabs/bin"

--- a/install-openvox-win.psh
+++ b/install-openvox-win.psh
@@ -1,7 +1,7 @@
 # Requires: PowerShell 5.0+
 $ErrorActionPreference = "Stop"
 
-$msiUrl = "https://artifacts.voxpupuli.org/downloads/windows/openvox8/openvox-agent-8.17.0-rc1-x64.msi"
+$msiUrl = "https://artifacts.voxpupuli.org/downloads/windows/openvox8/openvox-agent-8.19.2-x64.msi"
 $msiPath = "$env:TEMP\openvox-agent.msi"
 $installDir = "C:\Program Files\Puppet Labs\Puppet\bin"
 $linkDir = "$env:ProgramData\OpenVox\bin"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 AGENT_VERSION="${1:-8}"
 PKG_NAME="${2:-openvox-agent}"
-BASE_URL="https://voxpupuli.org"
+BASE_URL=${3:-"https://voxpupuli.org"}
+
 
 # macOS detection
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
  * prior to this self hosting and running on the cli meant hard coding the source url.  This allows for the user to pass the url in instead.

  * Updates beta agents to official versions for windows and mac

  * Note Mac and Windows agents are still hard coded to specific versions